### PR TITLE
Add PR permissions to CompatHelper

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -3,6 +3,9 @@ on:
   schedule:
     - cron: 23 01 * * TUE
   workflow_dispatch:
+permissions:
+  contents: write
+  pull-requests: write
 jobs:
   CompatHelper:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Trying to solve the failing of scheduled [CompatHelper jobs](https://github.com/JuliaPhylo/PhyloGaussianBeliefProp.jl/actions/runs/13779114457).

It looks that the issue has to do with [permissions](https://github.com/JuliaPhylo/PhyloGaussianBeliefProp.jl/actions/runs/13779114457/job/38533976622#step:3:93).

In the [default yml](https://github.com/JuliaRegistries/CompatHelper.jl/blob/master/.github/workflows/CompatHelper.yml#L6) provided by CompatHelper, they add write permissions to contents and pull requests.

I added these lines to our yml.

It might be that our workflow used to work because of more permissive [settings](https://github.com/JuliaPhylo/PhyloGaussianBeliefProp.jl/settings/actions) in GitHub.
I'm not sure if that changed when we moved to the JuliaPhylo organisation, but now default workflow permissions is read only, and the "allow gha to create and approve pr" is now unchecked. (And this cannot be changed, at least by me.)

**Questions**:
- I'm not sure how to check that this works, other than letting the next scheduled job run ?
- Should we use the complete CompatHelper [yml](https://github.com/JuliaRegistries/CompatHelper.jl/blob/master/.github/workflows/CompatHelper.yml), that looks more extensive (and maybe more up to date ?) than the one we use now ?